### PR TITLE
Add localName to control.js; (option added in pvanallen/ble-serial)

### DIFF
--- a/control.js
+++ b/control.js
@@ -14,7 +14,7 @@ var BLESerialPort = require('ble-serial').SerialPort;
 var keypress = require('keypress');
 
 //use the virtual serial port to send a command to a firmata device
-var bleSerial = new BLESerialPort();
+var bleSerial = new BLESerialPort({localName: 'FIRMATA'});
 var board = new five.Board({port: bleSerial, repl: false});
 
 board.on("ready", function() {


### PR DESCRIPTION
During meetups we are likely to have more than one device, so users will change the value of FIRMATA_BLE_LOCAL_NAME in bleConfig.h (in Arduino\Examples\StandardFirmataBLE folder).  This will make the Arduino transmit a unique name (if they don't change the name, the default is "FIRMATA").

There is a pull request people can apply at https://github.com/monteslu/ble-serial/pull/2 that has the ability to specify a localName in the options in the call to new BLESerialPort.

This change to control.js makes it so that we are using "FIRMATA" as the localName to connect to.  If people have changed the name of their bot, then they would have to change "FIRMATA" to match the name of their bot.